### PR TITLE
fix: Vite CSS override / build css import bug / assumed HTML import bug

### DIFF
--- a/examples/csr/src/modules/c/button/button.css
+++ b/examples/csr/src/modules/c/button/button.css
@@ -1,0 +1,5 @@
+@import 'c/cssShared';
+
+button {
+  background-color: var(--theme-primary-color, salmon);
+}

--- a/examples/csr/src/modules/c/button/button.html
+++ b/examples/csr/src/modules/c/button/button.html
@@ -1,0 +1,3 @@
+<template>
+  <button>I should be green</button>
+</template>

--- a/examples/csr/src/modules/c/button/button.js
+++ b/examples/csr/src/modules/c/button/button.js
@@ -1,0 +1,3 @@
+import { LightningElement } from "lwc";
+
+export default class Button extends LightningElement {}

--- a/examples/csr/src/modules/c/cssShared/cssShared.css
+++ b/examples/csr/src/modules/c/cssShared/cssShared.css
@@ -1,0 +1,3 @@
+:host {
+  --theme-primary-color: lawngreen;
+}

--- a/examples/csr/vite.config.ts
+++ b/examples/csr/vite.config.ts
@@ -1,8 +1,11 @@
 import type { UserConfig } from "vite";
 import lwc from "vite-plugin-lwc";
 
+import LWC_CONFIG from './lwc.config.json'
+
 export default {
   plugins: [lwc({
+    modules: LWC_CONFIG.modules,
     disableSyntheticShadowSupport: true,
   })],
 } satisfies UserConfig;

--- a/packages/vite-plugin-lwc/package.json
+++ b/packages/vite-plugin-lwc/package.json
@@ -47,6 +47,7 @@
   "homepage": "https://github.com/cardoso/vite-plugin-lwc/tree/main/packages/vite-plugin-lwc#readme",
   "peerDependencies": {
     "@lwc/rollup-plugin": ">= 8",
+    "rollup": ">= 4",
     "vite": ">= 6"
   },
   "devDependencies": {

--- a/packages/vite-plugin-lwc/src/constants.ts
+++ b/packages/vite-plugin-lwc/src/constants.ts
@@ -1,0 +1,3 @@
+// taken from `@lwc/rollup-plugin`
+export const IMPLICIT_DEFAULT_HTML_PATH = '@lwc/resources/empty_html.js' as const
+export const IMPLICIT_DEFAULT_CSS_PATH = '@lwc/resources/empty_css.css' as const

--- a/packages/vite-plugin-lwc/src/index.ts
+++ b/packages/vite-plugin-lwc/src/index.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
-import rollup from "rollup";
-import type { StringFilter, ObjectHook, TransformPluginContext } from "rollup";
+import type { StringFilter, ObjectHook, TransformResult, TransformPluginContext } from "rollup";
 import patch from "./patch.ts";
 import lwc from "./lwc.ts";
 import alias from "./alias.ts";
@@ -10,17 +9,22 @@ import type { ViteLwcOptions } from "./types.ts";
 import { normalizeOptions } from "./options.ts";
 import { IMPLICIT_DEFAULT_CSS_PATH, IMPLICIT_DEFAULT_HTML_PATH } from "./constants.ts";
 
-function transformOverride(
-  transform: { handler: Function },
-  viteOptions: ViteLwcOptions
-): ObjectHook<(this: TransformPluginContext, code: string, id: string, options?: {
+type TransformOverride = ObjectHook<(this: TransformPluginContext, code: string, id: string, options?: {
   ssr?: boolean;
-}) => Promise<rollup.TransformResult> | rollup.TransformResult, {
+}) => Promise<TransformResult> | TransformResult, {
+  handler(code: string, id: string, options: {
+    ssr?: boolean | undefined;
+  }): undefined,
   filter?: {
     id?: StringFilter;
     code?: StringFilter;
   };
-}> {
+}>
+
+function transformOverride(
+  transform: TransformOverride | null | undefined,
+  viteOptions: ViteLwcOptions
+): TransformOverride {
   // TODO: add support for `npm` modules. Currently relies on `dir|dirs` config
   const moduleDirs = viteOptions.modules?.reduce<string[]>((acc, item) => {
     const _item = (item as { dir?: string, dirs?: string })
@@ -36,7 +40,7 @@ function transformOverride(
 
   return {
     ...transform,
-    async handler(code: string, id: string, options: {
+    handler(code: string, id: string, options: {
       ssr?: boolean | undefined;
     } | undefined) {
       if (isLwcCss(id, moduleDirs)) {
@@ -44,9 +48,9 @@ function transformOverride(
          * These imports are handled by the LWC engine and
          * should be ignored by `vite:css`/`vite:css-post`.
          */
-        return undefined
+        return null
       } else {
-        return transform.handler?.call(this, code, id, options)
+        return transform?.handler?.call(this, code, id, options)
       }
     },
   }
@@ -99,13 +103,13 @@ export default (options: ViteLwcOptions = {}): Plugin[] => {
     patch({
       "vite:css": (p) => {
         p.transform = transformOverride(
-          (p.transform as unknown as { handler: Function; }),
+          p.transform,
           options
         );
       },
       "vite:css-post": (p) => {
         p.transform = transformOverride(
-          (p.transform as unknown as { handler: Function; }),
+          p.transform,
           options
         );
       },

--- a/packages/vite-plugin-lwc/src/index.ts
+++ b/packages/vite-plugin-lwc/src/index.ts
@@ -1,3 +1,6 @@
+import path from "node:path";
+import rollup from "rollup";
+import type { StringFilter, ObjectHook, TransformPluginContext } from "rollup";
 import patch from "./patch.ts";
 import lwc from "./lwc.ts";
 import alias from "./alias.ts";
@@ -5,28 +8,118 @@ import type { Plugin } from "vite";
 import hmr from "./hmr.ts";
 import type { ViteLwcOptions } from "./types.ts";
 import { normalizeOptions } from "./options.ts";
+import { IMPLICIT_DEFAULT_CSS_PATH, IMPLICIT_DEFAULT_HTML_PATH } from "./constants.ts";
+
+function transformOverride(
+  transform: { handler: Function },
+  viteOptions: ViteLwcOptions
+): ObjectHook<(this: TransformPluginContext, code: string, id: string, options?: {
+  ssr?: boolean;
+}) => Promise<rollup.TransformResult> | rollup.TransformResult, {
+  filter?: {
+    id?: StringFilter;
+    code?: StringFilter;
+  };
+}> {
+  // TODO: add support for `npm` modules. Currently relies on `dir|dirs` config
+  const moduleDirs = viteOptions.modules?.reduce<string[]>((acc, item) => {
+    const _item = (item as { dir?: string, dirs?: string })
+    if (_item.dir) {
+      acc.push(_item.dir)
+    }
+    if (_item.dirs) {
+      acc.push(..._item.dirs)
+    }
+
+    return acc
+  }, []) || []
+
+  return {
+    ...transform,
+    async handler(code: string, id: string, options: {
+      ssr?: boolean | undefined;
+    } | undefined) {
+      if (isLwcCss(id, moduleDirs)) {
+        /**
+         * These imports are handled by the LWC engine and
+         * should be ignored by `vite:css`/`vite:css-post`.
+         */
+        return undefined
+      } else {
+        return transform.handler?.call(this, code, id, options)
+      }
+    },
+  }
+}
+
+/**
+ * Simple "is LWC" check. Based on LWC module dir|dirs config passed
+ * to the plugin.
+ *
+ * @param {string} id - Id path to check
+ * @param {string[]} moduleDirs - list of module directories (from dir|dirs config)
+ * @returns {boolean}
+ */
+const isInModuleDirs = (id: string, moduleDirs: string[]) => {
+  const normalizeId = path.normalize(id)
+
+  // loop until a match is found (or fail through all matches)
+  for (const moduleDir of moduleDirs) {
+    // removes the `./` from the prefix so the full path of id matches
+    const normalizeDir = path.normalize(moduleDir)
+    const dirPath = normalizeDir.replace('./', '/')
+
+    if (normalizeId.includes(dirPath)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+const isLwcCss = (id: string, moduleDirs: string[]) => {
+  // should handle '@lwc/resources/empty_html.css' & '@lwc/resources/empty_css.css'
+  if (
+    isInModuleDirs(id, moduleDirs) ||
+    id.startsWith('c/') ||
+    id.includes(IMPLICIT_DEFAULT_HTML_PATH) ||
+    id.includes(IMPLICIT_DEFAULT_CSS_PATH)
+  ) {
+    return true
+  }
+
+  // continue with standard Vite CSS processing
+  return false
+}
+
 
 export default (options: ViteLwcOptions = {}): Plugin[] => {
   options = normalizeOptions(options);
   return [
-  patch({
-    "vite:css": (p) => {
-      p.transform = undefined;
+    patch({
+      "vite:css": (p) => {
+        p.transform = transformOverride(
+          (p.transform as unknown as { handler: Function; }),
+          options
+        );
+      },
+      "vite:css-post": (p) => {
+        p.transform = transformOverride(
+          (p.transform as unknown as { handler: Function; }),
+          options
+        );
+      },
+    }),
+    alias(),
+    {
+      ...lwc(options),
+      apply: "build",
     },
-    "vite:css-post": (p) => {
-      p.transform = undefined;
+    {
+      ...lwc(options),
+      enforce: "post",
+      apply: "serve",
     },
-  }),
-  alias(),
-  {
-    ...lwc(options),
-    apply: "build",
-  },
-  {
-    ...lwc(options),
-    enforce: "post",
-    apply: "serve",
-  },
-  hmr()
-]
+    hmr()
+  ]
 };

--- a/packages/vite-plugin-lwc/src/lwc.ts
+++ b/packages/vite-plugin-lwc/src/lwc.ts
@@ -1,7 +1,9 @@
 import { createFilter, type Plugin, type Rollup } from "vite";
 import lwc, { type RollupLwcOptions } from "@lwc/rollup-plugin";
+import fs from "node:fs";
 import path from "node:path";
 import type { ViteLwcOptions } from "./types";
+import { IMPLICIT_DEFAULT_HTML_PATH } from "./constants";
 
 function createRollupPlugin(options: RollupLwcOptions) {
   const plugin = lwc(options);
@@ -56,6 +58,32 @@ export default function lwcVite(config: ViteLwcOptions): Plugin {
     async resolveId(source, importer, options) {
       if (!filter(source)) {
         return;
+      }
+
+      /**
+       * When attempting to import HTML from a JS file, double check
+       * the file exists.
+       *
+       * Somewhat mimics the `@lwc/rollup-plugin` logic to prevent
+       * the assumption of a `.html` file for all LWCs.
+       */
+      if (
+        importer &&
+        path.extname(importer) === '.js' &&
+        path.isAbsolute(importer) &&
+        (path.extname(source) === '.html' || source.endsWith('html?import'))
+      ) {
+        const dir = path.dirname(importer)
+        let filePath = path.join(dir, source)
+
+        if (path.isAbsolute(source)) {
+          filePath = source
+        }
+
+        if (!fs.existsSync(filePath)) {
+          // taken from `@lwc/rollup-plugin`
+          return IMPLICIT_DEFAULT_HTML_PATH
+        }
       }
 
       if (

--- a/playground/lwc/src/modules/c/button/button.css
+++ b/playground/lwc/src/modules/c/button/button.css
@@ -1,0 +1,5 @@
+@import 'c/cssShared';
+
+button {
+  background-color: var(--theme-primary-color, salmon);
+}

--- a/playground/lwc/src/modules/c/button/button.html
+++ b/playground/lwc/src/modules/c/button/button.html
@@ -1,0 +1,3 @@
+<template>
+  <button>I should be green</button>
+</template>

--- a/playground/lwc/src/modules/c/button/button.js
+++ b/playground/lwc/src/modules/c/button/button.js
@@ -1,0 +1,3 @@
+import { LightningElement } from "lwc";
+
+export default class Button extends LightningElement {}

--- a/playground/lwc/src/modules/c/cssShared/cssShared.css
+++ b/playground/lwc/src/modules/c/cssShared/cssShared.css
@@ -1,0 +1,3 @@
+:host {
+  --theme-primary-color: lawngreen;
+}

--- a/playground/lwc/src/modules/c/main/main.html
+++ b/playground/lwc/src/modules/c/main/main.html
@@ -3,4 +3,5 @@
   <x-counter></x-counter>
   <c-dynamic-template></c-dynamic-template>
   <c-dynamic-template alternate></c-dynamic-template>
+  <c-button></c-button>
 </template>

--- a/playground/lwc/vite.config.mts
+++ b/playground/lwc/vite.config.mts
@@ -3,9 +3,13 @@ import lwc from "vite-plugin-lwc";
 
 const deps = ["lwc", "@lwc/engine-dom", "@lwc/synthetic-shadow", "@lwc/shared"];
 
+import LWC_CONFIG from './lwc.config.json'
+
 export default defineConfig({
   plugins: [
-    lwc(),
+    lwc({
+      modules: LWC_CONFIG.modules
+    }),
   ],
   root: import.meta.dirname,
   optimizeDeps: {


### PR DESCRIPTION
Still a WIP but...

Fixes:
1. `vite:css`/`vite:css-post` blanked overrides previously set to `undefined` for all, causing issues when using with other build tools (e.g. storybook)
2. importing CSS only LWCs from other LWCs (not too sure why, but looks like  some part of the `@lwc/engine-dom` isn't normalizing strings?)
3. assumes all LWCs should have a matching `*.html` import, quick check if the file exists or not

Should address https://github.com/cardoso/vite-plugin-lwc/issues/96 and (most of) https://github.com/cardoso/vite-plugin-lwc/discussions/95